### PR TITLE
Fix bug w/ reading nimble config w/ seq, and add option for normanBaseDir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,8 @@ Usage
 
     Initially, a placeholder model Model is defined in it to demonstrate how you can define your actual models.
 
+    You can set ``normanBaseDir`` in your ``.nimble`` file to use a different root directory for your ``models.nim`` file and ``models/*`` submodules.
+
 -   ``models`` is the models submodules directory. Initially, it's empty.
 -   ``config.nim`` is the project config file. Use it to set the DB backend and credentials across your project.
 

--- a/tests/tnorman.nim
+++ b/tests/tnorman.nim
@@ -1,4 +1,7 @@
 import unittest
+import os
+
+import norman
 
 
 suite "Norman commands":
@@ -10,3 +13,26 @@ suite "Norman commands":
 
   test "init":
     check true
+
+  test "get pkg dir from nimble file srcDir":
+    const contents = @["installExt    = @[\"nim\", \"nims\"]", "srcDir = \"src\""]
+    let nf = open("test.nimble", fmWrite)
+    nf.writeLine(contents)
+    nf.close()
+
+    let pkgDir = getPkgDirFromNimble("test.nimble")
+
+    removeFile("test.nimble")
+    check pkgDir == "src/test"
+
+  test "get pkg dir from nimble file normanBaseDir":
+    const contents = @["srcDir = \"src\"", "normanBaseDir = \"src/api\""]
+    let nf = open("test.nimble", fmWrite)
+    for line in contents:
+      nf.writeLine(line)
+    nf.close()
+
+    let pkgDir = getPkgDirFromNimble("test.nimble")
+
+    removeFile("test.nimble")
+    check pkgDir == "src/api"


### PR DESCRIPTION
Closes #5 

Allows developer to override the location of the model folders by setting `normanBaseDir` in their .nimble file.