### PR TITLE
Automatic `nimble.paths` inclusion and default `deepcopy` support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Usage
 
 6.  Apply migrations with ``norman migrate``:
 
-.. code-block:: language
+.. code-block::
 
     $ norman migrate
     Applying migrations:
@@ -215,19 +215,28 @@ Troubleshooting
 "Error: cannot open file: normanpkg/prelude"
 --------------------------------------------
 
-If you see this error, it means the migration cannot find the Norman library.
-To fix it, edit ``migrations/config.nims`` and add this line to the end:
+If you see this error, it is likely that you are using ``nimble setup`` (project isolation) but haven't re-run it after adding ``norman`` to your dependencies.
+
+**Solution:** Run ``nimble setup`` again in your project root.
+
+.. code-block::
+
+    $ nimble setup
+
+This updates ``nimble.paths`` to include ``norman``, allowing migrations to find it.
+
+If the error persists or you need to manually configure paths, ensure ``migrations/config.nims`` includes ``nimble.paths`` correctly:
 
 .. code-block:: nim
 
-    include "../nimble.paths"
+    when fileExists("$projectDir/../../nimble.paths"):
+      include "$projectDir/../../nimble.paths"
 
-And ensure the path to your source is correct (you may need an extra ``../``):
+And ensure the path to your source is correct:
 
 .. code-block:: nim
 
-    switch("path", "$projectDir/../../../src")
-
+    switch("path", "$projectDir/../../src")
 
 "Error: 'deepcopy' support has to be enabled"
 ---------------------------------------------

--- a/src/normanpkg/private/templates/config.nimf
+++ b/src/normanpkg/private/templates/config.nimf
@@ -3,3 +3,6 @@
 switch("path", "$$projectDir/../../src")
 switch("hints", "off")
 switch("verbosity", "0")
+
+when fileExists(projectDir() & "/../../nimble.paths"):
+  include "$$projectDir/../../nimble.paths"

--- a/src/normanpkg/private/templates/config.nimf
+++ b/src/normanpkg/private/templates/config.nimf
@@ -3,6 +3,7 @@
 switch("path", "$$projectDir/../../src")
 switch("hints", "off")
 switch("verbosity", "0")
+switch("deepcopy", "on")
 
 when fileExists(projectDir() & "/../../nimble.paths"):
   include "$$projectDir/../../nimble.paths"


### PR DESCRIPTION
### `nimble.paths` inclusion
Fixes the "cannot open file: normanpkg/prelude" error when using `nimble setup`.

Previously, Norman migrations did not correctly detect or include the `nimble.paths` file generated by `nimble setup` when it contained the `--noNimblePath` flag. 

Reproduction steps:
1. Initialize a new binary package:  `nimble init foo`
2. Run nimble setup to create a `nimble.paths` file (this adds --noNimblePath)
3. Add `norm` and `norman` to project dependency: `nimble add norm norman`
4. Run `norman init` and `norman generate -i user`
5. Run `norman migrate`

Before:
Fails with `/tmp/foo/migrations/xxx_init/migration.nim(1, 18) Error: cannot open file: normanpkg/prelude`.

After:
config.nims correctly locates `../../nimble.paths` (relative to the migration file) and includes it.

### Default deepcopy support
Enables `deepcopy:on` by default for all migration tasks.

Reproduction steps:
1. Set up a project with `norm` and `norman`
2. Apply a migration
3. Run `norman undo`

Before:
Fails with a runtime error regarding missing `deepcopy` support.

After:
`switch("deepcopy", "on")` is automatically added to the generated `migrations/config.nims`, preventing this error.

### Documentation update

- Updated README troubleshooting section to advise running `nimble setup` as the primary fix for path issues. 
- Updated manual configuration examples to use the correct ../../ relative path depth.

Closes #13 